### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,6 @@ jobs:
         run: go test -count=1 ./...
 
       - name: Build
-        run: go build -trimpath -o bin/imsgcrawl ./cmd/imsgcrawl
+        run: |
+          mkdir -p bin
+          go build -trimpath -o bin/imsgcrawl ./cmd/imsgcrawl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,13 @@ jobs:
         run: go vet ./...
 
       - name: Deadcode
-        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+        run: |
+          output_file=$(mktemp)
+          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Test
         run: go test -count=1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify module cache
+        run: go mod verify
+
+      - name: Check go.mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Deadcode
+        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+
+      - name: Test
+        run: go test -count=1 ./...
+
+      - name: Build
+        run: go build -trimpath -o bin/imsgcrawl ./cmd/imsgcrawl


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- add CI vet/test/build coverage for the new repository workflow
- create the build output directory after autoreview caught the missing `bin` parent

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -count=1 ./...`
- `go build -trimpath -o bin/imsgcrawl ./cmd/imsgcrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
