### PR TITLE
fix: publish clean release asset names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,8 @@ changelog:
 builds:
   - id: imsgcrawl
     main: ./cmd/imsgcrawl
-    binary: imsgcrawl
+    binary: "{{ .Os }}_{{ .Arch }}/imsgcrawl"
+    no_unique_dist_dir: true
     env:
       - CGO_ENABLED=0
     flags:
@@ -27,9 +28,9 @@ archives:
     formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    strip_binary_directory: true
     files:
       - README.md
-      - LICENSE
 
 checksum:
   name_template: checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.1.1 - 2026-07-18
+
+### Highlights
+
+- Publish platform archives with clean, stable filenames that match the crawler family convention
+
+### Release engineering
+
+- Place GoReleaser binaries in target-only output directories so the unified packager omits internal build IDs and architecture variant suffixes from asset names
 
 ## 0.1.0 - 2026-07-18
 


### PR DESCRIPTION
## Summary

- put GoReleaser binaries in target-only output directories so the unified packager emits clean family-standard asset names
- strip those target directories from normal GoReleaser archives as well
- remove the nonexistent license file from the archive payload
- prepare 0.1.1 release notes for the corrected download surface

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `actionlint .github/workflows/*.yml`
- `goreleaser check`
- `goreleaser release --snapshot --clean`
- target directories are exactly Darwin/Linux amd64/arm64; archives use clean names and contain the binary at archive root
